### PR TITLE
Fixed headings on example tables to reflect actual code.

### DIFF
--- a/example/mapreduce-example/README.md
+++ b/example/mapreduce-example/README.md
@@ -4,7 +4,7 @@ This example demonstrates using the MapReduce client for Palisade and shows a Ma
 
 The database has been hardcoded in class: uk.gov.gchq.palisade.example.data.ExampleSimpleDataReader and has been loaded with the following records:
 
-| Value         | Visibility           | Timestamp  |
+| Property      | Visibility           | Timestamp  |
 | ------------- | -------------------- | ---------- |
 |  item1a       |   public             | 1          |
 |  item1b       |   public             | 10         |

--- a/example/multi-jvm-example/README.md
+++ b/example/multi-jvm-example/README.md
@@ -4,7 +4,7 @@ This example demonstrates 2 different users querying a database over a REST api.
 
 The database has been hardcoded in class: uk.gov.gchq.palisade.example.data.ExampleSimpleDataReader and has been loaded with the following records:
 
-| Value         | Visibility           | Timestamp  |
+| Property      | Visibility           | Timestamp  |
 | ------------- | -------------------- | ---------- |
 |  item1a       |   public             | 1          |
 |  item1b       |   public             | 10         |

--- a/example/single-jvm-example/README.md
+++ b/example/single-jvm-example/README.md
@@ -4,7 +4,7 @@ This example demonstrates 2 different users querying a database.
 
 The database has been hardcoded in class: uk.gov.gchq.palisade.example.data.ExampleSimpleDataReader and has been loaded with the following records:
 
-| Value         | Visibility           | Timestamp  |
+| Property      | Visibility           | Timestamp  |
 | ------------- | -------------------- | ---------- |
 |  item1a       |   public             | 1          |
 |  item1b       |   public             | 10         |


### PR DESCRIPTION
Just a simple correction to the documentation, as discussed.