### PR TITLE
Optionally build the example modules based on the profile of build se…

### DIFF
--- a/cd/install.sh
+++ b/cd/install.sh
@@ -3,6 +3,6 @@
 set -e
 
 if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-    echo "Running install script: mvn -q install -P quick,travis -B -V"
-    mvn -q install -P quick -B -V
+    echo "Running install script: mvn -q install -B -V"
+    mvn -q install -B -V
 fi

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -25,10 +25,59 @@
     <artifactId>example</artifactId>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>example-model</module>
-        <module>single-jvm-example</module>
-        <module>multi-jvm-example</module>
-        <module>mapreduce-example</module>
-    </modules>
+    <profiles>
+        <!-- full build default option, integration-test and test profile build examples.-->
+        <profile>
+            <id>full</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>example-model</module>
+                <module>single-jvm-example</module>
+                <module>multi-jvm-example</module>
+                <module>mapreduce-example</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>integration-test</id>
+            <modules>
+                <module>example-model</module>
+                <module>single-jvm-example</module>
+                <module>multi-jvm-example</module>
+                <module>mapreduce-example</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>test</id>
+            <modules>
+                <module>example-model</module>
+                <module>single-jvm-example</module>
+                <module>multi-jvm-example</module>
+                <module>mapreduce-example</module>
+            </modules>
+        </profile>
+
+        <!-- quick build, unit-test, analyze and styling dont build examples -->
+        <profile>
+            <id>quick</id>
+            <modules>
+            </modules>
+        </profile>
+        <profile>
+            <id>unit-test</id>
+            <modules>
+            </modules>
+        </profile>
+        <profile>
+            <id>analyze</id>
+            <modules>
+            </modules>
+        </profile>
+        <profile>
+            <id>styling</id>
+            <modules>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
…lected, if no profile selected build by default

When quick, unit-test, analyze, or styline build dont build the example modules.

In the other profiles, or if no profile is selected build all of the example modules.