### PR TITLE
Gh 168 data service personal

### DIFF
--- a/example/multi-jvm-example/multi-jvm-example-rest-data-service/pom.xml
+++ b/example/multi-jvm-example/multi-jvm-example-rest-data-service/pom.xml
@@ -125,6 +125,11 @@
                                     <!-- This file exists in the example-model module -->
                                     configRest.json
                                 </palisade.rest.config.path>
+                                <!-- Here you could override the Data service implementing class
+                                <uk.gov.gchq.palisade.data.service.DataService>
+                                    uk.gov.gchq.palisade.data.service.impl.SimpleDataService
+                                </uk.gov.gchq.palisade.data.service.DataService>
+                                -->
                                 <palisade.error-mode.debug>
                                     true
                                 </palisade.error-mode.debug>

--- a/example/multi-jvm-example/multi-jvm-example-rest-data-service/pom.xml
+++ b/example/multi-jvm-example/multi-jvm-example-rest-data-service/pom.xml
@@ -125,7 +125,8 @@
                                     <!-- This file exists in the example-model module -->
                                     configRest.json
                                 </palisade.rest.config.path>
-                                <!-- Here you could override the Data service implementing class
+                                <!-- Here you could override the Data service implementing class-->
+                                <!--
                                 <uk.gov.gchq.palisade.data.service.DataService>
                                     uk.gov.gchq.palisade.data.service.impl.SimpleDataService
                                 </uk.gov.gchq.palisade.data.service.DataService>

--- a/service-impl/data-service-impl/rest-data-service/src/main/java/uk/gov/gchq/palisade/data/service/impl/RestDataServiceV1.java
+++ b/service-impl/data-service-impl/rest-data-service/src/main/java/uk/gov/gchq/palisade/data/service/impl/RestDataServiceV1.java
@@ -71,7 +71,8 @@ public class RestDataServiceV1 implements DataService {
 
     private static synchronized DataService createService(final String serviceConfigPath) {
         if (dataService == null) {
-            dataService = RestUtil.createService(RestDataServiceV1.class, serviceConfigPath, DataService.class);
+            //note that here we specifically allow the DataService implementing class to be overridden from a system property
+            dataService = RestUtil.createService(RestDataServiceV1.class, serviceConfigPath, DataService.class, DataService.class.getTypeName());
         }
         return dataService;
     }

--- a/service/config-service/src/test/java/uk/gov/gchq/palisade/config/service/ConfiguratorTest.java
+++ b/service/config-service/src/test/java/uk/gov/gchq/palisade/config/service/ConfiguratorTest.java
@@ -15,9 +15,11 @@
  */
 package uk.gov.gchq.palisade.config.service;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import sun.security.krb5.Config;
 import uk.gov.gchq.palisade.config.service.request.GetConfigRequest;
 import uk.gov.gchq.palisade.exception.NoConfigException;
 import uk.gov.gchq.palisade.service.Service;
@@ -27,20 +29,21 @@ import java.time.Duration;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.PatternSyntaxException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ServiceConfiguratorTest {
+public class ConfiguratorTest {
 
     public interface TestService extends Service {
-
     }
 
     public static class TestServiceImpl implements TestService {
@@ -52,6 +55,22 @@ public class ServiceConfiguratorTest {
             throw new NoSuchElementException("test");
         }
     }
+
+    private static ServiceConfiguration testConfig;
+    private static final String KEY1 = "key1";
+    private static final String KEY2 = "key2";
+    private static final String VALUE1 = "value1";
+    private static final String VALUE2 = "value2";
+    private static final String VALUE3 = "value3";
+
+
+    @BeforeClass
+    public static void setupConfig() {
+        testConfig = new ServiceConfiguration();
+        testConfig.put(KEY1, VALUE1);
+        testConfig.put(KEY2, VALUE2);
+    }
+
 
     @Test(expected = IllegalArgumentException.class)
     public void throwOnNegativeTimeout() {
@@ -147,5 +166,89 @@ public class ServiceConfiguratorTest {
 
         //Then
         fail("exception expected");
+    }
+
+    @Test(expected = PatternSyntaxException.class)
+    public void throwOnIllegalPattern() {
+        //Given - nothing
+        //When
+        Configurator.applyOverrides(testConfig, "[[[["); //illegal regex
+        //Then
+        fail("exception expected");
+    }
+
+    @Test
+    public void shouldBeSameWhenNoneMatch() {
+        //Given - nothing
+        //When
+        ServiceConfiguration actual = Configurator.applyOverrides(testConfig, "no match");
+        //Then
+        assertEquals(testConfig.getConfig().size(), actual.getConfig().size());
+        assertEquals(testConfig, actual);
+    }
+
+    @Test
+    public void shouldBeSameWhenPropNotPresent() {
+        //Given
+        System.clearProperty(KEY1);
+        //When
+        ServiceConfiguration actual = Configurator.applyOverrides(testConfig, KEY1);
+        //Then
+        assertEquals(testConfig.getConfig().size(), actual.getConfig().size());
+        assertEquals(testConfig, actual);
+    }
+
+    @Test
+    public void shouldChangeWhenPresent() {
+        //Given
+        System.setProperty(KEY2, VALUE3);
+        ServiceConfiguration expected = new ServiceConfiguration();
+        expected.put(KEY1, VALUE1);
+        expected.put(KEY2, VALUE3);
+        //When
+        ServiceConfiguration actual = Configurator.applyOverrides(testConfig, KEY2);
+        System.clearProperty(KEY2);
+        //Then
+        assertEquals(expected.getConfig().size(), actual.getConfig().size());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldBeSameWhenPropPresentNoneMatch() {
+        //Given
+        System.setProperty(KEY2, VALUE3);
+        //When
+        ServiceConfiguration actual = Configurator.applyOverrides(testConfig, KEY1);
+        System.clearProperty(KEY2);
+        //Then
+        assertEquals(testConfig.getConfig().size(), actual.getConfig().size());
+        assertEquals(testConfig, actual);
+    }
+
+    @Test
+    public void shouldBeSameWithEmptyOverrides() {
+        //Given
+        System.setProperty(KEY1, VALUE3);
+        //When
+        ServiceConfiguration actual = Configurator.applyOverrides(testConfig, "");
+        System.clearProperty(KEY1);
+        //Then
+        assertEquals(testConfig.getConfig().size(), actual.getConfig().size());
+        assertEquals(testConfig, actual);
+    }
+
+    @Test
+    public void shouldChangeOnWildcard() {
+        //Given
+        System.setProperty(KEY2, VALUE3);
+        ServiceConfiguration expected = new ServiceConfiguration();
+        expected.put(KEY1, VALUE1);
+        expected.put(KEY2, VALUE3);
+        //When
+        ServiceConfiguration actual = Configurator.applyOverrides(testConfig, KEY2);
+        System.clearProperty(KEY2);
+        //Then
+        assertEquals(expected.getConfig().size(), actual.getConfig().size());
+        assertEquals(expected, actual);
     }
 }

--- a/service/config-service/src/test/java/uk/gov/gchq/palisade/config/service/ConfiguratorTest.java
+++ b/service/config-service/src/test/java/uk/gov/gchq/palisade/config/service/ConfiguratorTest.java
@@ -62,8 +62,7 @@ public class ConfiguratorTest {
     private static final String VALUE1 = "value1";
     private static final String VALUE2 = "value2";
     private static final String VALUE3 = "value3";
-
-
+    
     @BeforeClass
     public static void setupConfig() {
         testConfig = new ServiceConfiguration();

--- a/service/config-service/src/test/java/uk/gov/gchq/palisade/config/service/ConfiguratorTest.java
+++ b/service/config-service/src/test/java/uk/gov/gchq/palisade/config/service/ConfiguratorTest.java
@@ -62,7 +62,7 @@ public class ConfiguratorTest {
     private static final String VALUE1 = "value1";
     private static final String VALUE2 = "value2";
     private static final String VALUE3 = "value3";
-    
+
     @BeforeClass
     public static void setupConfig() {
         testConfig = new ServiceConfiguration();

--- a/service/rest-service/core-rest-service/src/main/java/uk/gov/gchq/palisade/rest/RestUtil.java
+++ b/service/rest-service/core-rest-service/src/main/java/uk/gov/gchq/palisade/rest/RestUtil.java
@@ -24,7 +24,6 @@ import uk.gov.gchq.palisade.exception.NoConfigException;
 import uk.gov.gchq.palisade.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.palisade.service.Service;
 import uk.gov.gchq.palisade.service.request.ConfigConsts;
-import uk.gov.gchq.palisade.service.request.ServiceConfiguration;
 import uk.gov.gchq.palisade.util.StreamUtil;
 
 import java.io.InputStream;
@@ -52,7 +51,7 @@ public final class RestUtil {
      * @param overridable       list of regular expressions for keys that can be overridden from system properties
      * @param <S>               type of service being returned
      * @return an instantiated configured service
-     * @see Configurator#createFromConfig(Class, ServiceConfiguration, String...)
+     * @see Configurator#createFromConfig(Class, uk.gov.gchq.palisade.service.request.ServiceConfiguration, String...)
      */
     public static <S extends Service> S createService(final Class<?> resolverClass, final String configDetailsPath, final Class<S> serviceClass, final String... overridable) {
         //create config service object

--- a/service/rest-service/core-rest-service/src/main/java/uk/gov/gchq/palisade/rest/RestUtil.java
+++ b/service/rest-service/core-rest-service/src/main/java/uk/gov/gchq/palisade/rest/RestUtil.java
@@ -42,7 +42,7 @@ public final class RestUtil {
      * Attempts to create the configured {@link Service}. This method provides the boot strapping for the REST services
      * to instantiate their services to which they delegate the actual implementations. This method will attempt to load
      * the {@link ConfigurationService} class details from the given path. Once this has been instantiated, it
-     * will repeatedly call the configuration service trying to ge the name of the actual implementing class for the
+     * will repeatedly call the configuration service trying to get the name of the actual implementing class for the
      * given service and then configure it.
      *
      * @param resolverClass     the class to resolve the {@code configDetailsPath} against


### PR DESCRIPTION
Fixes gh-168. We allow certain keys in the ServiceConfiguration to be overridable via system properties. For example in the RestDataService, the key for the class implementing the data service can be overridden. This allows the specific type of data service created to be controllable via system property. This can then be controlled via external processes, e.g. an orchestration system. Thus if we have two data services. DataServiceTypeA and DataServiceTypeB, all the orchestration service has to do is start instances of dataservices with the system property uk.gov.gchq.palisade.data.service.DataService=DataServiceTypeA for example to create one. As long as the ServiceConfiguration contains the config for all types of data service present, then we can support and start multiple different dataservices within one Palisade deployment.