### PR TITLE
configure services exit

### DIFF
--- a/example/example-model/src/main/java/uk/gov/gchq/palisade/example/config/DistributedServices.java
+++ b/example/example-model/src/main/java/uk/gov/gchq/palisade/example/config/DistributedServices.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.palisade.example.config;
 
+import uk.gov.gchq.palisade.cache.service.CacheService;
+import uk.gov.gchq.palisade.cache.service.impl.SimpleCacheService;
+
 /**
  * Convenience class for setting the default config for the various Palisade micro-services
  * which assumes all services are being deployed according to the given arguments.
@@ -28,6 +31,12 @@ public final class DistributedServices {
     }
 
     public static void main(final String[] args) {
-        new ServicesConfigurator(new ProxyServicesFactory(args));
+        ProxyServicesFactory factory=new ProxyServicesFactory(args);
+        new ServicesConfigurator(factory);
+
+        CacheService cs=factory.createCacheService();
+        if (cs instanceof SimpleCacheService) {
+            ((SimpleCacheService)cs).getBackingStore().close();
+        }
     }
 }

--- a/example/example-model/src/main/java/uk/gov/gchq/palisade/example/config/DistributedServices.java
+++ b/example/example-model/src/main/java/uk/gov/gchq/palisade/example/config/DistributedServices.java
@@ -31,12 +31,12 @@ public final class DistributedServices {
     }
 
     public static void main(final String[] args) {
-        ProxyServicesFactory factory=new ProxyServicesFactory(args);
+        ProxyServicesFactory factory = new ProxyServicesFactory(args);
         new ServicesConfigurator(factory);
 
-        CacheService cs=factory.createCacheService();
+        CacheService cs = factory.createCacheService();
         if (cs instanceof SimpleCacheService) {
-            ((SimpleCacheService)cs).getBackingStore().close();
+            ((SimpleCacheService) cs).getBackingStore().close();
         }
     }
 }

--- a/example/example-model/src/main/java/uk/gov/gchq/palisade/example/config/ProxyServicesFactory.java
+++ b/example/example-model/src/main/java/uk/gov/gchq/palisade/example/config/ProxyServicesFactory.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -88,15 +89,20 @@ public class ProxyServicesFactory {
         return new ProxyRestConnectionDetail().url(args[5]).serviceClass(ProxyRestDataService.class);
     }
 
+    private CacheService cacheService;
+
     public CacheService createCacheService() {
-        if (args.length > 1) {
-            List<URI> etcdEndpoints = Arrays.stream(args[0].split(",")).map(URI::create).collect(Collectors.toList());
-            return new SimpleCacheService().backingStore(new EtcdBackingStore().connectionDetails(etcdEndpoints));
-        } else {
-            LOGGER.error("Failed to create the Configuration for the cache service due to missing the 1st argument, " +
-                    "which should be a comma separated list of etcd client endpoints");
-            throw new RuntimeException("failed to create CacheService due to no etcd endpoints specified");
+        if (isNull(cacheService)) {
+            if (args.length > 1) {
+                List<URI> etcdEndpoints = Arrays.stream(args[0].split(",")).map(URI::create).collect(Collectors.toList());
+                cacheService = new SimpleCacheService().backingStore(new EtcdBackingStore().connectionDetails(etcdEndpoints));
+            } else {
+                LOGGER.error("Failed to create the Configuration for the cache service due to missing the 1st argument, " +
+                        "which should be a comma separated list of etcd client endpoints");
+                throw new RuntimeException("failed to create CacheService due to no etcd endpoints specified");
+            }
         }
+        return cacheService;
     }
 
     public AuditService createAuditService() {

--- a/service-impl/cache-service-impl/etcd-backing-store/src/main/java/uk/gov/gchq/palisade/cache/service/impl/EtcdBackingStore.java
+++ b/service-impl/cache-service-impl/etcd-backing-store/src/main/java/uk/gov/gchq/palisade/cache/service/impl/EtcdBackingStore.java
@@ -65,6 +65,7 @@ public class EtcdBackingStore implements BackingStore {
     public EtcdBackingStore() {
     }
 
+    @Override
     public void close() {
         if (null != keyValueClient) {
             keyValueClient.close();

--- a/service-impl/cache-service-impl/simple-cache-service/src/main/java/uk/gov/gchq/palisade/cache/service/impl/BackingStore.java
+++ b/service-impl/cache-service-impl/simple-cache-service/src/main/java/uk/gov/gchq/palisade/cache/service/impl/BackingStore.java
@@ -112,6 +112,12 @@ public interface BackingStore {
     Stream<String> list(final String prefix);
 
     /**
+     * Closes the backing store. This method must be idempotent.
+     */
+    default void close() {
+    }
+
+    /**
      * Check the provided key is not empty.
      *
      * @param key the backing store key


### PR DESCRIPTION
The CacheService connections contains an EtcdBackingStore which contains a connection to Etcd. This connection is held in a separate thread which keeps the main JVM alive once all other code is exited. This fix includes code to manually close the connection once the main thread exits.