### PR TITLE
added a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*/swagger/* linguist-vendored


### PR DESCRIPTION
added a .gitattributes file so the github linguist can ignore the swagger files when auto-detecting the project programming language