### PR TITLE
fixed bug in the example deployments

### DIFF
--- a/example/deployment/AWS-EC2-S3/terraform-scripts/InstanceRunningPalisade/main.tf
+++ b/example/deployment/AWS-EC2-S3/terraform-scripts/InstanceRunningPalisade/main.tf
@@ -43,7 +43,7 @@ resource "local_file" "hadoop_s3" {
 }
 resource "null_resource" "create_palisade_instance" {
   provisioner "local-exec" {
-    command = "sed -i 's/eu-west-1/${var.aws_region}/g' ../../../../resources/hadoop_s3.xml"
+    command = "sed -i -e 's/eu-west-1/${var.aws_region}/g' ../../../../resources/hadoop_s3.xml"
   }
 }
 # create instance running Palisade

--- a/example/deployment/AWS-EMR/terraform-scripts/palisade_cluster.tf
+++ b/example/deployment/AWS-EMR/terraform-scripts/palisade_cluster.tf
@@ -23,6 +23,10 @@ resource "aws_emr_cluster" "palisade_cluster" {
     instance_role  = "MASTER"
     instance_type  = "${var.master_instance_type}"
     instance_count = "${var.master_instance_count}"
+    ebs_config {
+      size = 50
+      type = "gp2"
+    }
   }
 
   instance_group {


### PR DESCRIPTION
fixed a bug in the EC2 example where the sed command was missing the -e flag and also added extra storage to the AWS EMR example master node so we can generate larger data sets