### PR TITLE
PAL 185 - Added .clone() .equals() .hashCode() methods to hr-generator types

### DIFF
--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Address.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Address.java
@@ -23,13 +23,23 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Random;
 
-public class Address implements Cloneable {
-
+public class Address {
     private String streetAddressNumber;
     private String streetName;
     private String city;
     private String state;
     private String zipCode;
+
+    public Address() {
+    }
+
+    public Address(final Address address) {
+        streetAddressNumber = address.streetAddressNumber;
+        streetName = address.streetName;
+        city = address.city;
+        state = address.state;
+        zipCode = address.zipCode;
+    }
 
     public static Address generate(final Faker faker, final Random random) {
         Address address = new Address();
@@ -91,24 +101,6 @@ public class Address implements Cloneable {
                 .append("state", state)
                 .append("zipCode", zipCode)
                 .toString();
-    }
-
-    public Address clone() {
-        Address clone;
-        try {
-            clone = (Address) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new Address();
-        }
-
-        // Immutable
-        clone.setStreetAddressNumber(streetAddressNumber);
-        clone.setStreetName(streetName);
-        clone.setCity(city);
-        clone.setState(state);
-        clone.setZipCode(zipCode);
-
-        return clone;
     }
 
     @Override

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Address.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Address.java
@@ -17,11 +17,13 @@
 package uk.gov.gchq.palisade.example.hrdatagenerator.types;
 
 import com.github.javafaker.Faker;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Random;
 
-public class Address {
+public class Address implements Cloneable {
 
     private String streetAddressNumber;
     private String streetName;
@@ -89,5 +91,55 @@ public class Address {
                 .append("state", state)
                 .append("zipCode", zipCode)
                 .toString();
+    }
+
+    public Address clone() {
+        Address clone;
+        try {
+            clone = (Address) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            clone = new Address();
+        }
+
+        // Immutable
+        clone.setStreetAddressNumber(streetAddressNumber);
+        clone.setStreetName(streetName);
+        clone.setCity(city);
+        clone.setState(state);
+        clone.setZipCode(zipCode);
+
+        return clone;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Address address = (Address) o;
+
+        return new EqualsBuilder()
+                .append(streetAddressNumber, address.streetAddressNumber)
+                .append(streetName, address.streetName)
+                .append(city, address.city)
+                .append(state, address.state)
+                .append(zipCode, address.zipCode)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(11, 41)
+                .append(streetAddressNumber)
+                .append(streetName)
+                .append(city)
+                .append(state)
+                .append(zipCode)
+                .toHashCode();
     }
 }

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/BankDetails.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/BankDetails.java
@@ -16,6 +16,8 @@
 
 package uk.gov.gchq.palisade.example.hrdatagenerator.types;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Random;
@@ -61,6 +63,47 @@ public class BankDetails {
                 .append("sortCode", sortCode)
                 .append("accountNumber", accountNumber)
                 .toString();
+    }
+
+    public BankDetails clone() {
+        BankDetails clone;
+        try {
+            clone = (BankDetails) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            clone = new BankDetails();
+        }
+
+        // Immutable
+        clone.setSortCode(sortCode);
+        clone.setAccountNumber(accountNumber);
+
+        return clone;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final BankDetails bankDetails = (BankDetails) o;
+
+        return new EqualsBuilder()
+                .append(sortCode, bankDetails.sortCode)
+                .append(accountNumber, bankDetails.accountNumber)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(15, 45)
+                .append(sortCode)
+                .append(accountNumber)
+                .toHashCode();
     }
 }
 

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/BankDetails.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/BankDetails.java
@@ -26,6 +26,14 @@ public class BankDetails {
     private String sortCode;
     private String accountNumber;
 
+    public BankDetails() {
+    }
+
+    public BankDetails(final BankDetails bankDetails) {
+        sortCode = bankDetails.sortCode;
+        accountNumber = bankDetails.accountNumber;
+    }
+
     public static BankDetails generate(final Random random) {
         BankDetails bankDetails = new BankDetails();
         StringBuilder sortCode = new StringBuilder(String.valueOf(random.nextInt(999999)));
@@ -63,21 +71,6 @@ public class BankDetails {
                 .append("sortCode", sortCode)
                 .append("accountNumber", accountNumber)
                 .toString();
-    }
-
-    public BankDetails clone() {
-        BankDetails clone;
-        try {
-            clone = (BankDetails) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new BankDetails();
-        }
-
-        // Immutable
-        clone.setSortCode(sortCode);
-        clone.setAccountNumber(accountNumber);
-
-        return clone;
     }
 
     @Override

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/EmergencyContact.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/EmergencyContact.java
@@ -29,6 +29,25 @@ public class EmergencyContact {
     private Relation relation;
     private PhoneNumber[] contactNumbers;
 
+    public EmergencyContact() {
+    }
+
+    public EmergencyContact(final EmergencyContact emergencyContact) {
+        contactName = emergencyContact.contactName;
+        relation = emergencyContact.relation;
+
+        // Nested
+        if (emergencyContact.contactNumbers != null) {
+            int arrayLen = emergencyContact.contactNumbers.length;
+            contactNumbers = new PhoneNumber[arrayLen];
+            for (int i = 0; i < arrayLen; i++) {
+                if (emergencyContact.contactNumbers[i] != null) {
+                    contactNumbers[i] = new PhoneNumber(emergencyContact.contactNumbers[i]);
+                }
+            }
+        }
+    }
+
     public static EmergencyContact generate(final Faker faker, final Random random) {
         EmergencyContact contact = new EmergencyContact();
         Name tempName = faker.name();
@@ -80,30 +99,6 @@ public class EmergencyContact {
                 .append("relation", relation)
                 .append("contactNumbers", contactNumbers)
                 .toString();
-    }
-
-    public EmergencyContact clone() {
-        EmergencyContact clone;
-        try {
-            clone = (EmergencyContact) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new EmergencyContact();
-        }
-
-        // Immutable
-        clone.setContactName(contactName);
-        clone.setRelation(relation);
-
-        // Nested
-        if (null != contactNumbers) {
-            PhoneNumber[] cloneContactNumbers = contactNumbers.clone();
-            for (int i = 0; i < cloneContactNumbers.length; i++) {
-                cloneContactNumbers[i] = cloneContactNumbers[i].clone();
-            }
-            clone.setContactNumbers(cloneContactNumbers);
-        }
-
-        return clone;
     }
 
     @Override

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/EmergencyContact.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/EmergencyContact.java
@@ -18,6 +18,8 @@ package uk.gov.gchq.palisade.example.hrdatagenerator.types;
 
 import com.github.javafaker.Faker;
 import com.github.javafaker.Name;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Random;
@@ -78,5 +80,57 @@ public class EmergencyContact {
                 .append("relation", relation)
                 .append("contactNumbers", contactNumbers)
                 .toString();
+    }
+
+    public EmergencyContact clone() {
+        EmergencyContact clone;
+        try {
+            clone = (EmergencyContact) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            clone = new EmergencyContact();
+        }
+
+        // Immutable
+        clone.setContactName(contactName);
+        clone.setRelation(relation);
+
+        // Nested
+        if (null != contactNumbers) {
+            PhoneNumber[] cloneContactNumbers = contactNumbers.clone();
+            for (int i = 0; i < cloneContactNumbers.length; i++) {
+                cloneContactNumbers[i] = cloneContactNumbers[i].clone();
+            }
+            clone.setContactNumbers(cloneContactNumbers);
+        }
+
+        return clone;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final EmergencyContact emergencyContact = (EmergencyContact) o;
+
+        return new EqualsBuilder()
+                .append(contactName, emergencyContact.contactName)
+                .append(relation, emergencyContact.relation)
+                .append(contactNumbers, emergencyContact.contactNumbers)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(15, 47)
+                .append(contactName)
+                .append(relation)
+                .append(contactNumbers)
+                .toHashCode();
     }
 }

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Employee.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Employee.java
@@ -18,6 +18,8 @@ package uk.gov.gchq.palisade.example.hrdatagenerator.types;
 
 import com.github.javafaker.Faker;
 import com.github.javafaker.Name;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import uk.gov.gchq.palisade.UserId;
@@ -232,5 +234,121 @@ public class Employee {
                 .append("workLocation", workLocation)
                 .append("sex", sex)
                 .toString();
+    }
+
+    public Employee clone() {
+        Employee clone;
+        try {
+            clone = (Employee) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            clone = new Employee();
+        }
+
+        // Immutable
+        clone.setDateOfBirth(dateOfBirth);
+        clone.setTaxCode(taxCode);
+        clone.setNationality(nationality);
+        clone.setHireDate(hireDate);
+        clone.setGrade(grade);
+        clone.setDepartment(department);
+        clone.setSalaryAmount(salaryAmount);
+        clone.setSalaryBonus(salaryBonus);
+        clone.setSex(sex);
+        clone.setName(name);
+
+        // Mutable
+        if (null != uid) {
+            clone.setUid(uid.clone());
+        }
+        if (null != workLocation) {
+            clone.setWorkLocation(workLocation.clone());
+        }
+        if (null != bankDetails) {
+            clone.setBankDetails(bankDetails.clone());
+        }
+        if (null != address) {
+            clone.setAddress(address.clone());
+        }
+
+        // Nested
+        if (null != contactNumbers) {
+            PhoneNumber[] cloneContactNumbers = contactNumbers.clone();
+            for (int i = 0; i < cloneContactNumbers.length; i++) {
+                cloneContactNumbers[i] = cloneContactNumbers[i].clone();
+            }
+            clone.setContactNumbers(cloneContactNumbers);
+        }
+        if (null != emergencyContacts) {
+            EmergencyContact[] cloneEmergencyContacts = emergencyContacts.clone();
+            for (int i = 0; i < cloneEmergencyContacts.length; i++) {
+                cloneEmergencyContacts[i] = cloneEmergencyContacts[i].clone();
+            }
+            clone.setEmergencyContacts(cloneEmergencyContacts);
+        }
+        if (null != manager) {
+            Manager[] cloneManagers = manager.clone();
+            for (int i = 0; i < manager.length; i++) {
+                cloneManagers[i] = cloneManagers[i].clone();
+            }
+            clone.setManager(cloneManagers);
+        }
+
+        return clone;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Employee employee = (Employee) o;
+
+        return new EqualsBuilder()
+                .append(uid, employee.uid)
+                .append(name, employee.name)
+                .append(dateOfBirth, employee.dateOfBirth)
+                .append(contactNumbers, employee.contactNumbers)
+                .append(emergencyContacts, employee.emergencyContacts)
+                .append(address, employee.address)
+                .append(bankDetails, employee.bankDetails)
+                .append(taxCode, employee.taxCode)
+                .append(nationality, employee.nationality)
+                .append(manager, employee.manager)
+                .append(hireDate, employee.hireDate)
+                .append(grade, employee.grade)
+                .append(department, employee.department)
+                .append(salaryAmount, employee.salaryAmount)
+                .append(salaryBonus, employee.salaryBonus)
+                .append(workLocation, employee.workLocation)
+                .append(sex, employee.sex)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(7, 45)
+                .append(uid)
+                .append(name)
+                .append(dateOfBirth)
+                .append(contactNumbers)
+                .append(emergencyContacts)
+                .append(address)
+                .append(bankDetails)
+                .append(taxCode)
+                .append(nationality)
+                .append(manager)
+                .append(hireDate)
+                .append(grade)
+                .append(department)
+                .append(salaryAmount)
+                .append(salaryBonus)
+                .append(workLocation)
+                .append(sex)
+                .toHashCode();
     }
 }

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Employee.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Employee.java
@@ -28,7 +28,6 @@ import uk.gov.gchq.palisade.example.hrdatagenerator.utils.DateHelper;
 import java.util.Random;
 
 public class Employee {
-
     private UserId uid;
     private String name;
     private String dateOfBirth;
@@ -47,6 +46,64 @@ public class Employee {
     private WorkLocation workLocation;
     private Sex sex;
 
+    public Employee() {
+    }
+
+    public Employee(final Employee employee) {
+        name = employee.name;
+        dateOfBirth = employee.dateOfBirth;
+        taxCode = employee.taxCode;
+        nationality = employee.nationality;
+        hireDate = employee.hireDate;
+        grade = employee.grade;
+        department = employee.department;
+        salaryAmount = employee.salaryAmount;
+        salaryBonus = employee.salaryBonus;
+        sex = employee.sex;
+
+        if (employee.uid != null) {
+            uid = employee.uid.clone();
+        }
+
+        if (employee.address != null) {
+            address = new Address(employee.address);
+        }
+        if (employee.bankDetails != null) {
+            bankDetails = new BankDetails(employee.bankDetails);
+        }
+        if (employee.workLocation != null) {
+            workLocation = new WorkLocation(employee.workLocation);
+        }
+
+        // Nested
+        if (employee.contactNumbers != null) {
+            int arrayLen = employee.contactNumbers.length;
+            contactNumbers = new PhoneNumber[arrayLen];
+            for (int i = 0; i < arrayLen; i++) {
+                if (employee.contactNumbers[i] != null) {
+                    contactNumbers[i] = new PhoneNumber(employee.contactNumbers[i]);
+                }
+            }
+        }
+        if (employee.emergencyContacts != null) {
+            int arrayLen = employee.emergencyContacts.length;
+            emergencyContacts = new EmergencyContact[arrayLen];
+            for (int i = 0; i < arrayLen; i++) {
+                if (employee.emergencyContacts[i] != null) {
+                    emergencyContacts[i] = new EmergencyContact(employee.emergencyContacts[i]);
+                }
+            }
+        }
+        if (employee.manager != null) {
+            int arrayLen = employee.manager.length;
+            manager = new Manager[arrayLen];
+            for (int i = 0; i < arrayLen; i++) {
+                if (employee.manager[i] != null) {
+                    manager[i] = new Manager(employee.manager[i]);
+                }
+            }
+        }
+    }
 
     public static Employee generate(final Random random) {
         Employee employee = new Employee();
@@ -234,66 +291,6 @@ public class Employee {
                 .append("workLocation", workLocation)
                 .append("sex", sex)
                 .toString();
-    }
-
-    public Employee clone() {
-        Employee clone;
-        try {
-            clone = (Employee) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new Employee();
-        }
-
-        // Immutable
-        clone.setDateOfBirth(dateOfBirth);
-        clone.setTaxCode(taxCode);
-        clone.setNationality(nationality);
-        clone.setHireDate(hireDate);
-        clone.setGrade(grade);
-        clone.setDepartment(department);
-        clone.setSalaryAmount(salaryAmount);
-        clone.setSalaryBonus(salaryBonus);
-        clone.setSex(sex);
-        clone.setName(name);
-
-        // Mutable
-        if (null != uid) {
-            clone.setUid(uid.clone());
-        }
-        if (null != workLocation) {
-            clone.setWorkLocation(workLocation.clone());
-        }
-        if (null != bankDetails) {
-            clone.setBankDetails(bankDetails.clone());
-        }
-        if (null != address) {
-            clone.setAddress(address.clone());
-        }
-
-        // Nested
-        if (null != contactNumbers) {
-            PhoneNumber[] cloneContactNumbers = contactNumbers.clone();
-            for (int i = 0; i < cloneContactNumbers.length; i++) {
-                cloneContactNumbers[i] = cloneContactNumbers[i].clone();
-            }
-            clone.setContactNumbers(cloneContactNumbers);
-        }
-        if (null != emergencyContacts) {
-            EmergencyContact[] cloneEmergencyContacts = emergencyContacts.clone();
-            for (int i = 0; i < cloneEmergencyContacts.length; i++) {
-                cloneEmergencyContacts[i] = cloneEmergencyContacts[i].clone();
-            }
-            clone.setEmergencyContacts(cloneEmergencyContacts);
-        }
-        if (null != manager) {
-            Manager[] cloneManagers = manager.clone();
-            for (int i = 0; i < manager.length; i++) {
-                cloneManagers[i] = cloneManagers[i].clone();
-            }
-            clone.setManager(cloneManagers);
-        }
-
-        return clone;
     }
 
     @Override

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Manager.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Manager.java
@@ -16,13 +16,15 @@
 
 package uk.gov.gchq.palisade.example.hrdatagenerator.types;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import uk.gov.gchq.palisade.UserId;
 
 import java.util.Random;
 
-public class Manager {
+public class Manager implements Cloneable {
     private UserId uid;
     private Manager[] manager;
     private String managerType;
@@ -84,5 +86,61 @@ public class Manager {
                 .append("uid", uid)
                 .append("manager", manager)
                 .toString();
+    }
+
+    public Manager clone() {
+        Manager clone;
+        try {
+            clone = (Manager) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            clone = new Manager();
+        }
+
+        // Immutable
+        clone.setManagerType(managerType);
+
+        // Mutable
+        if (null != uid) {
+            clone.setUid(uid.clone());
+        }
+
+        // Nested
+        if (null != manager) {
+            Manager[] cloneManagers = manager.clone();
+            for (int i = 0; i < manager.length; i++) {
+                cloneManagers[i] = cloneManagers[i].clone();
+            }
+            clone.setManager(cloneManagers);
+        }
+
+        return clone;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Manager otherManager = (Manager) o;
+
+        return new EqualsBuilder()
+                .append(uid, otherManager.uid)
+                .append(manager, otherManager.manager)
+                .append(managerType, otherManager.managerType)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(15, 43)
+                .append(uid)
+                .append(manager)
+                .append(managerType)
+                .toHashCode();
     }
 }

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Manager.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/Manager.java
@@ -24,10 +24,32 @@ import uk.gov.gchq.palisade.UserId;
 
 import java.util.Random;
 
-public class Manager implements Cloneable {
+public class Manager {
     private UserId uid;
     private Manager[] manager;
     private String managerType;
+
+    public Manager() {
+    }
+
+    public Manager(final Manager otherManager) {
+        managerType = otherManager.managerType;
+
+        if (otherManager.uid != null) {
+            uid = otherManager.uid.clone();
+        }
+
+        // Nested
+        if (otherManager.manager != null) {
+            int arrayLen = otherManager.manager.length;
+            manager = new Manager[arrayLen];
+            for (int i = 0; i < arrayLen; i++) {
+                if (otherManager.manager[i] != null) {
+                    manager[i] = new Manager(otherManager.manager[i]);
+                }
+            }
+        }
+    }
 
     public static Manager[] generateMany(final Random random, final int chain) {
         Manager[] managers = new Manager[3];
@@ -86,34 +108,6 @@ public class Manager implements Cloneable {
                 .append("uid", uid)
                 .append("manager", manager)
                 .toString();
-    }
-
-    public Manager clone() {
-        Manager clone;
-        try {
-            clone = (Manager) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new Manager();
-        }
-
-        // Immutable
-        clone.setManagerType(managerType);
-
-        // Mutable
-        if (null != uid) {
-            clone.setUid(uid.clone());
-        }
-
-        // Nested
-        if (null != manager) {
-            Manager[] cloneManagers = manager.clone();
-            for (int i = 0; i < manager.length; i++) {
-                cloneManagers[i] = cloneManagers[i].clone();
-            }
-            clone.setManager(cloneManagers);
-        }
-
-        return clone;
     }
 
     @Override

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/PhoneNumber.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/PhoneNumber.java
@@ -16,11 +16,13 @@
 
 package uk.gov.gchq.palisade.example.hrdatagenerator.types;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Random;
 
-public class PhoneNumber {
+public class PhoneNumber implements Cloneable {
     private String type; // is this a home number, work number, mobile number ...
     private String phoneNumber;
     private static final String[] DEFAULT_TYPES = new String[]{"Mobile"};
@@ -77,5 +79,46 @@ public class PhoneNumber {
                 .append("type", type)
                 .append("phone number", phoneNumber)
                 .toString();
+    }
+
+    public PhoneNumber clone() {
+        PhoneNumber clone;
+        try {
+            clone = (PhoneNumber) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            clone = new PhoneNumber();
+        }
+
+        // Immutable
+        clone.setType(type);
+        clone.setPhoneNumber(phoneNumber);
+
+        return clone;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final PhoneNumber otherNumber = (PhoneNumber) o;
+
+        return new EqualsBuilder()
+                .append(type, otherNumber.type)
+                .append(phoneNumber, otherNumber.phoneNumber)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 43)
+                .append(type)
+                .append(phoneNumber)
+                .toHashCode();
     }
 }

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/PhoneNumber.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/PhoneNumber.java
@@ -22,11 +22,19 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Random;
 
-public class PhoneNumber implements Cloneable {
+public class PhoneNumber {
     private String type; // is this a home number, work number, mobile number ...
     private String phoneNumber;
     private static final String[] DEFAULT_TYPES = new String[]{"Mobile"};
     private static final String[] POSSIBLE_TYPES = new String[]{"Home", "Work", "Work Mobile"};
+
+    public PhoneNumber() {
+    }
+
+    public PhoneNumber(final PhoneNumber otherNumber) {
+        type = otherNumber.type;
+        phoneNumber = otherNumber.phoneNumber;
+    }
 
     public static PhoneNumber[] generateMany(final Random random) {
         int numberOfExtraContacts = random.nextInt(3);
@@ -79,21 +87,6 @@ public class PhoneNumber implements Cloneable {
                 .append("type", type)
                 .append("phone number", phoneNumber)
                 .toString();
-    }
-
-    public PhoneNumber clone() {
-        PhoneNumber clone;
-        try {
-            clone = (PhoneNumber) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new PhoneNumber();
-        }
-
-        // Immutable
-        clone.setType(type);
-        clone.setPhoneNumber(phoneNumber);
-
-        return clone;
     }
 
     @Override

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/WorkLocation.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/WorkLocation.java
@@ -17,11 +17,13 @@
 package uk.gov.gchq.palisade.example.hrdatagenerator.types;
 
 import com.github.javafaker.Faker;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Random;
 
-public class WorkLocation {
+public class WorkLocation implements Cloneable {
     private WorkLocationName workLocationName;
     private Address address;
 
@@ -47,12 +49,58 @@ public class WorkLocation {
         workLocation.setWorkLocationName(WorkLocationName.generate(random));
         return workLocation;
     }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .append("workLocationName", workLocationName)
                 .append("address", address)
                 .toString();
+    }
+
+    public WorkLocation clone() {
+        WorkLocation clone;
+        try {
+            clone = (WorkLocation) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            clone = new WorkLocation();
+        }
+
+        // Immutable
+        clone.setWorkLocationName(workLocationName);
+
+        // Mutable
+        if (null != address) {
+            clone.setAddress(address.clone());
+        }
+
+        return clone;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final WorkLocation workLocation = (WorkLocation) o;
+
+        return new EqualsBuilder()
+                .append(workLocationName, workLocation.workLocationName)
+                .append(address, workLocation.address)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 41)
+                .append(workLocationName)
+                .append(address)
+                .toHashCode();
     }
 }
 

--- a/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/WorkLocation.java
+++ b/example/hr-data-generator/src/main/java/uk/gov/gchq/palisade/example/hrdatagenerator/types/WorkLocation.java
@@ -23,9 +23,20 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Random;
 
-public class WorkLocation implements Cloneable {
+public class WorkLocation {
     private WorkLocationName workLocationName;
     private Address address;
+
+    public WorkLocation() {
+    }
+
+    public WorkLocation(final WorkLocation workLocation) {
+        workLocationName = workLocation.workLocationName;
+
+        if (workLocation.address != null) {
+            address = new Address(workLocation.address);
+        }
+    }
 
     public  WorkLocationName getWorkLocationName() {
         return workLocationName;
@@ -56,25 +67,6 @@ public class WorkLocation implements Cloneable {
                 .append("workLocationName", workLocationName)
                 .append("address", address)
                 .toString();
-    }
-
-    public WorkLocation clone() {
-        WorkLocation clone;
-        try {
-            clone = (WorkLocation) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new WorkLocation();
-        }
-
-        // Immutable
-        clone.setWorkLocationName(workLocationName);
-
-        // Mutable
-        if (null != address) {
-            clone.setAddress(address.clone());
-        }
-
-        return clone;
     }
 
     @Override

--- a/example/hr-data-generator/src/test/java/uk/gov/gchq/palisade/example/hrdatagenerator/EmployeeTest.java
+++ b/example/hr-data-generator/src/test/java/uk/gov/gchq/palisade/example/hrdatagenerator/EmployeeTest.java
@@ -19,12 +19,42 @@ package uk.gov.gchq.palisade.example.hrdatagenerator;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
+import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
 import uk.gov.gchq.palisade.example.hrdatagenerator.types.Employee;
 
 import java.io.File;
 import java.util.Random;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(Theories.class)
 public class EmployeeTest {
+
+    // Equal
+    private static Random randomA = new Random(0);
+    private static Random randomB = new Random(0);
+    private static Random randomC = new Random(0);
+    // Not equal
+    private static Random randomX = new Random(1);
+    private static Random randomY = new Random(2);
+
+    // Equal
+    @DataPoint
+    public static final Employee aliceA = Employee.generate(randomA);
+    @DataPoint
+    public static final Employee aliceB = Employee.generate(randomB);
+    @DataPoint
+    public static final Employee aliceC = Employee.generate(randomC);
+    // Not equal
+    @DataPoint
+    public static final Employee bob = Employee.generate(randomX);
+    @DataPoint
+    public static final Employee charlie = Employee.generate(randomY);
 
     @Test
     public void generateEmployee() {
@@ -44,6 +74,60 @@ public class EmployeeTest {
         } finally {
             FileUtils.deleteQuietly(new File(".data"));
         }
+    }
+
+    @Theory
+    public void testClone(Employee x) {
+        // Given
+        Employee cloneOfX = x.clone();
+        // Then
+        assertThat(x, equalTo(cloneOfX));
+    }
+
+    @Theory
+    public void testReflexiveEquals(Employee x) {
+        // Then
+        assertThat(x, equalTo(x));
+    }
+
+    @Theory
+    public void testNullEquals(Employee x) {
+        // Then
+        assertThat(x, not(equalTo(nullValue())));
+    }
+
+    @Theory
+    public void testSymmetricEquals(Employee x, Employee y) {
+        // Given
+        assumeThat(x, equalTo(y));
+        // Then
+        assertThat(y, equalTo(x));
+    }
+
+    @Theory
+    public void testTransitiveEquals(Employee x, Employee y, Employee z) {
+        // Given
+        assumeThat(x, equalTo(y));
+        assumeThat(y, equalTo(z));
+        // Then
+        assertThat(x, equalTo(z));
+    }
+
+    @Theory
+    public void testConsistentHashCode(Employee x) {
+        // Then
+        assertThat(x.hashCode(), equalTo(x.hashCode()));
+    }
+
+    @Theory
+    public void testEquivalentHashCode(Employee x, Employee y) {
+        // Then (using clone)
+        assertThat(x.hashCode(), equalTo(x.clone().hashCode()));
+
+        // Given
+        assumeThat(x, equalTo(y));
+        // Then
+        assertThat(x.hashCode(), equalTo(y.hashCode()));
     }
 
 }

--- a/example/hr-data-generator/src/test/java/uk/gov/gchq/palisade/example/hrdatagenerator/EmployeeTest.java
+++ b/example/hr-data-generator/src/test/java/uk/gov/gchq/palisade/example/hrdatagenerator/EmployeeTest.java
@@ -19,13 +19,14 @@ package uk.gov.gchq.palisade.example.hrdatagenerator;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
-import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 import uk.gov.gchq.palisade.example.hrdatagenerator.types.Employee;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -35,26 +36,27 @@ import static org.junit.Assume.assumeThat;
 @RunWith(Theories.class)
 public class EmployeeTest {
 
-    // Equal
-    private static Random randomA = new Random(0);
-    private static Random randomB = new Random(0);
-    private static Random randomC = new Random(0);
-    // Not equal
-    private static Random randomX = new Random(1);
-    private static Random randomY = new Random(2);
+    private static Random random = new Random(1);
 
-    // Equal
-    @DataPoint
-    public static final Employee aliceA = Employee.generate(randomA);
-    @DataPoint
-    public static final Employee aliceB = Employee.generate(randomB);
-    @DataPoint
-    public static final Employee aliceC = Employee.generate(randomC);
-    // Not equal
-    @DataPoint
-    public static final Employee bob = Employee.generate(randomX);
-    @DataPoint
-    public static final Employee charlie = Employee.generate(randomY);
+    // While this can be done by annotating generateEmployeeDataPoints directly, this results in a big performance hit
+    // as the (expensive) generate function is called for each data point for each argument (i.e. x1, x6, x31, x156, ...)
+    // This is a known but unaddressed JUnit bug.
+    // Instead, 'cache' the result of the function call.
+    private static Employee[] generateEmployeeDataPoints() {
+        ArrayList<Employee> dataPoints = new ArrayList<Employee>();
+        // Identical copies of Employee
+        for (int i = 0; i < 3; i++) {
+            dataPoints.add(Employee.generate(new Random(1)));
+        }
+        // Uniquely generated Employees
+        Random random = new Random(2);
+        for (int i = 0; i < 2; i++) {
+            dataPoints.add(Employee.generate(random));
+        }
+        return dataPoints.toArray(new Employee[dataPoints.size()]);
+    }
+    @DataPoints
+    public static final Employee[] employeeDataPoints = generateEmployeeDataPoints();
 
     @Test
     public void generateEmployee() {
@@ -77,11 +79,11 @@ public class EmployeeTest {
     }
 
     @Theory
-    public void testClone(Employee x) {
+    public void testCopyConstructor(Employee x) {
         // Given
-        Employee cloneOfX = x.clone();
+        Employee copy = new Employee(x);
         // Then
-        assertThat(x, equalTo(cloneOfX));
+        assertThat(x, equalTo(copy));
     }
 
     @Theory
@@ -120,10 +122,15 @@ public class EmployeeTest {
     }
 
     @Theory
-    public void testEquivalentHashCode(Employee x, Employee y) {
-        // Then (using clone)
-        assertThat(x.hashCode(), equalTo(x.clone().hashCode()));
+    public void testEqualHashCodeWhenCopied(Employee x) {
+        // Given
+        Employee copy = new Employee(x);
+        // Then
+        assertThat(x.hashCode(), equalTo(copy.hashCode()));
+    }
 
+    @Theory
+    public void testEqualHashCodeWhenEqual(Employee x, Employee y) {
         // Given
         assumeThat(x, equalTo(y));
         // Then


### PR DESCRIPTION
While not likely necessary for production, this is required for testing to validate (a lack of) changes to records after applying Rules