### PR TITLE
PAL-855 streaming architecture quickstart

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -26,7 +26,7 @@ Before running, make sure you have installed and appropriately-configured the fo
 * [Git](https://git-scm.com/downloads)
 * [OpenJDK Java 11](https://openjdk.java.net/projects/jdk/11/) or [Oracle Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
 * [Apache Kafka](https://kafka.apache.org/downloads) and [Redis](https://redis.io/download) available at `localhost:9092` and `localhost:6379` respectively
-  * for a quick-and-easy option, the Palisade-examples repo comes bundled with a [docker-compose file](https://github.com/gchq/Palisade-examples/blob/develop/deployment/local-jvm/docker-compose.yml) for Kafka, Zookeeper and Redis - `docker-compose -f Palisade-examples/deployment/local-jvm/docker-compose.yml up`
+  * for a quick-and-easy option, the Palisade-examples repo comes bundled with a [docker-compose file](https://github.com/gchq/Palisade-examples/tree/develop/deployment/local-jvm/docker-compose.yml) for Kafka, Zookeeper and Redis - `docker-compose -f Palisade-examples/deployment/local-jvm/docker-compose.yml up`
 
 ## Running the Quickstart Script
 Run the cross-platform [quickstart.cmd script](quickstart.cmd):
@@ -40,10 +40,10 @@ Run the cross-platform [quickstart.cmd script](quickstart.cmd):
   ```
 
 This will perform the following tasks necessary to set-up and start using Palisade:
-* Download each of the Palisade repos required to run the example ([common](https://github.com/gchq/Palisade-common/tree/palisade-0.5.0), [readers](https://github.com/gchq/Palisade-readers/tree/palisade-0.5.0), [clients](https://github.com/gchq/Palisade-clients/tree/palisade-0.5.0), [services](https://github.com/gchq/Palisade-services/tree/palisade-0.5.0), [examples](https://github.com/gchq/Palisade-examples/tree/palisade-0.5.0))
+* Download each of the Palisade repos required to run the example ([common](https://github.com/gchq/Palisade-common/tree/develop), [readers](https://github.com/gchq/Palisade-readers/tree/develop), [clients](https://github.com/gchq/Palisade-clients/tree/develop), [services](https://github.com/gchq/Palisade-services/tree/develop), [examples](https://github.com/gchq/Palisade-examples/tree/develop))
     - Since Palisade remains in active development, we will be pulling the 0.5.0 release which uses a REST-based microservice architecture
 * Install each project in order of any dependencies
-* Run the Palisade local-jvm example (more details [can be found here](https://github.com/gchq/Palisade-examples/tree/palisade-0.5.0/deployment/local-jvm))
+* Run the Palisade local-jvm example (more details [can be found here](https://github.com/gchq/Palisade-examples/tree/develop/deployment/local-jvm))
 
 Once complete, you will have each of the Palisade projects cloned to your local machine.
 Each Palisade module will be installed into your `~/.m2` cache and jars built to the appropriate `.../target` directories.
@@ -52,7 +52,7 @@ The services will be running locally in separate JVM processes.
 The script will have done an example run-through of Palisade, demonstrating a client with different users and purposes querying some Avro files for employee data, with some redaction and masking rules in place.
 The output of this example run-through will be written to the terminal once it has completed.
 The logging output of all the services can be found in the `Palisade-services` directory.
-More details of these rules and data structures [can be found here](https://github.com/gchq/Palisade-examples/tree/palisade-0.5.0/example-library).
+More details of these rules and data structures [can be found here](https://github.com/gchq/Palisade-examples/tree/develop/example-library).
 
 This shutdown procedure can be automated using the [quickstop.cmd script](quickstop.cmd):
 * On Linux/MacOS:
@@ -68,5 +68,5 @@ See the individual repositories and modules for their specific documentation fro
 ## Alternative Deployments
 
 ### Kubernetes
-Palisade is also set-up for a kubernetes deployment, which [is documented here](https://github.com/gchq/Palisade-examples/tree/palisade-0.5.0/deployment/local-k8s).
+Palisade is also set-up for a kubernetes deployment, which [is documented here](https://github.com/gchq/Palisade-examples/tree/develop/deployment/local-k8s).
 Under this setup, the `Palisade-services` directory will need to be rebuilt with a `mvn install` (the `quickstart.cmd` script uses a `-Pquick` profile which skips docker image builds).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,6 +1,5 @@
-
 <!---
-Copyright 2020 Crown Copyright
+Copyright 2018-2021 Crown Copyright
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,7 +39,7 @@ Run the cross-platform [quickstart.cmd script](quickstart.cmd):
 
 This will perform the following tasks necessary to set-up and start using Palisade:
 * Download each of the Palisade repos required to run the example ([common](https://https://github.com/gchq/Palisade-common), [readers](https://github.com/gchq/Palisade-readers), [clients](https://github.com/gchq/Palisade-clients), [services](https://github.com/gchq/Palisade-services), [examples](https://github.com/gchq/Palisade-examples))
-    - Since Palisade remains in active development, we will be pulling the 0.4.0 release which uses a REST-based microservice architecture
+    - Since Palisade remains in active development, we will be pulling the 0.5.0 release which uses a REST-based microservice architecture
 * Install each project in order of any dependencies
 * Run the Palisade local-jvm example (more details [can be found here](https://github.com/gchq/Palisade-examples/tree/develop/deployment/local-jvm))
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -19,12 +19,14 @@ limitations under the License.
 ## Getting started
 
 ### Prerequisites
+The repo comes bundled with the following:
+* [Apache Maven 3.6.3](https://maven.apache.org/download.cgi) via `mvnw`
+
 Before running, make sure you have installed and appropriately-configured the following:
 * [Git](https://git-scm.com/downloads)
 * [OpenJDK Java 11](https://openjdk.java.net/projects/jdk/11/) or [Oracle Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
-
-The repo comes bundled with the following:
-* [Apache Maven 3.6.3](https://maven.apache.org/download.cgi) via `mvnw`
+* [Apache Kafka](https://kafka.apache.org/downloads) and [Redis](https://redis.io/download) available at `localhost:9092` and `localhost:6379` respectively
+  * for a quick-and-easy option, the Palisade-examples repo comes bundled with a [docker-compose file](https://github.com/gchq/Palisade-examples/blob/develop/deployment/local-jvm/docker-compose.yml) for Kafka, Zookeeper and Redis - `docker-compose -f Palisade-examples/deployment/local-jvm/docker-compose.yml up`
 
 ## Running the Quickstart Script
 Run the cross-platform [quickstart.cmd script](quickstart.cmd):
@@ -38,10 +40,10 @@ Run the cross-platform [quickstart.cmd script](quickstart.cmd):
   ```
 
 This will perform the following tasks necessary to set-up and start using Palisade:
-* Download each of the Palisade repos required to run the example ([common](https://https://github.com/gchq/Palisade-common), [readers](https://github.com/gchq/Palisade-readers), [clients](https://github.com/gchq/Palisade-clients), [services](https://github.com/gchq/Palisade-services), [examples](https://github.com/gchq/Palisade-examples))
+* Download each of the Palisade repos required to run the example ([common](https://github.com/gchq/Palisade-common/tree/palisade-0.5.0), [readers](https://github.com/gchq/Palisade-readers/tree/palisade-0.5.0), [clients](https://github.com/gchq/Palisade-clients/tree/palisade-0.5.0), [services](https://github.com/gchq/Palisade-services/tree/palisade-0.5.0), [examples](https://github.com/gchq/Palisade-examples/tree/palisade-0.5.0))
     - Since Palisade remains in active development, we will be pulling the 0.5.0 release which uses a REST-based microservice architecture
 * Install each project in order of any dependencies
-* Run the Palisade local-jvm example (more details [can be found here](https://github.com/gchq/Palisade-examples/tree/develop/deployment/local-jvm))
+* Run the Palisade local-jvm example (more details [can be found here](https://github.com/gchq/Palisade-examples/tree/palisade-0.5.0/deployment/local-jvm))
 
 Once complete, you will have each of the Palisade projects cloned to your local machine.
 Each Palisade module will be installed into your `~/.m2` cache and jars built to the appropriate `.../target` directories.
@@ -50,9 +52,8 @@ The services will be running locally in separate JVM processes.
 The script will have done an example run-through of Palisade, demonstrating a client with different users and purposes querying some Avro files for employee data, with some redaction and masking rules in place.
 The output of this example run-through will be written to the terminal once it has completed.
 The logging output of all the services can be found in the `Palisade-services` directory.
-More details of these rules and data structures [can be found here](https://github.com/gchq/Palisade-examples/tree/develop/example-library).
+More details of these rules and data structures [can be found here](https://github.com/gchq/Palisade-examples/tree/palisade-0.5.0/example-library).
 
-The running services can be viewed from a Eureka dashboard visible at [http://localhost:8083](http://localhost:8083).
 This shutdown procedure can be automated using the [quickstop.cmd script](quickstop.cmd):
 * On Linux/MacOS:
   ```
@@ -67,5 +68,5 @@ See the individual repositories and modules for their specific documentation fro
 ## Alternative Deployments
 
 ### Kubernetes
-Palisade is also set-up for a kubernetes deployment, which [is documented here](https://github.com/gchq/Palisade-examples/tree/develop/deployment/local-k8s).
+Palisade is also set-up for a kubernetes deployment, which [is documented here](https://github.com/gchq/Palisade-examples/tree/palisade-0.5.0/deployment/local-k8s).
 Under this setup, the `Palisade-services` directory will need to be rebuilt with a `mvn install` (the `quickstart.cmd` script uses a `-Pquick` profile which skips docker image builds).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -41,7 +41,7 @@ Run the cross-platform [quickstart.cmd script](quickstart.cmd):
 
 This will perform the following tasks necessary to set-up and start using Palisade:
 * Download each of the Palisade repos required to run the example ([common](https://github.com/gchq/Palisade-common/tree/develop), [readers](https://github.com/gchq/Palisade-readers/tree/develop), [clients](https://github.com/gchq/Palisade-clients/tree/develop), [services](https://github.com/gchq/Palisade-services/tree/develop), [examples](https://github.com/gchq/Palisade-examples/tree/develop))
-    - Since Palisade remains in active development, we will be pulling the 0.5.0 release which uses a REST-based microservice architecture
+    - Since Palisade remains in active development, we will be pulling the 0.5.0 release which uses a Kafka-based streaming microservice architecture
 * Install each project in order of any dependencies
 * Run the Palisade local-jvm example (more details [can be found here](https://github.com/gchq/Palisade-examples/tree/develop/deployment/local-jvm))
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2020 Crown Copyright
+Copyright 2018-2021 Crown Copyright
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ Of course, Palisade can still be deployed locally on a per-platform basis.
 
 ### Additional Information 
 For a quickstart in using Palisade, [see the guide here](QUICKSTART.md).
-For more information on Palisade, [take a look here](https://gchq.github.io/Palisade/doc/developer_guide.html).
+For more information on Palisade, [take a look here](doc/developer_guide.md).
 
 
 For any questions or help please contact using the GitHub Issue tracking system.

--- a/quickstart.cmd
+++ b/quickstart.cmd
@@ -32,7 +32,7 @@ GOTO :CMDSCRIPT
 for dir in Palisade-common Palisade-readers Palisade-clients Palisade-services Palisade-examples
 do
     # Clone it (0.5.0 release)
-    git clone --depth 1 --branch palisade-0.5.0 https://github.com/gchq/$dir.git
+    git clone --depth 1 --branch develop https://github.com/gchq/$dir.git
     cd $dir
     # Install it (skip dockerfile, tests, javadoc, etc.)
     ../mvnw install -Pquick
@@ -60,7 +60,7 @@ set "dir_list=Palisade-common Palisade-readers Palisade-clients Palisade-service
 FOR %%s IN (%dir_list%) DO (
     set "url=https://github.com/gchq/%%s.git"
     REM clone it
-    git clone --depth 1 --branch palisade-0.5.0 "!url!"
+    git clone --depth 1 --branch develop "!url!"
     cd %%s
     REM install it
     call ../mvnw.cmd install -Pquick

--- a/quickstart.cmd
+++ b/quickstart.cmd
@@ -42,7 +42,7 @@ done
 : # Run the REST example
 cd Palisade-services
 java -Dspring.profiles.active=discovery -Dmanager.mode=run -jar services-manager/target/services-manager-*-exec.jar
-java -Dspring.profiles.active=example-model -Dmanager.mode=run -jar services-manager/target/services-manager-*-exec.jar
+java -Dspring.profiles.active=example-runner -Dmanager.mode=run -jar services-manager/target/services-manager-*-exec.jar
 cat rest-example.log
 cd ..
 
@@ -71,6 +71,6 @@ FOR %%s IN (%dir_list%) DO (
 : # Run the REST example
 cd Palisade-services
 java -D"spring.profiles.active=discovery" -D"manager.mode=run" -jar services-manager/target/services-manager-0.4.0-exec.jar
-java -D"spring.profiles.active=example-model" -D"manager.mode=run" -jar services-manager/target/services-manager-0.4.0-exec.jar
+java -D"spring.profiles.active=example-runner" -D"manager.mode=run" -jar services-manager/target/services-manager-0.4.0-exec.jar
 cat rest-example.log
 cd ..

--- a/quickstart.cmd
+++ b/quickstart.cmd
@@ -36,7 +36,7 @@ do
     cd $dir
     # Install it (skip dockerfile, tests, javadoc, etc.)
     ../mvnw install -Pquick
-    cd ..:
+    cd ..
 done
 
 : # Run the REST example

--- a/quickstart.cmd
+++ b/quickstart.cmd
@@ -1,4 +1,4 @@
-: # Copyright 2020 Crown Copyright
+: # Copyright 2018-2021 Crown Copyright
 : #
 : # Licensed under the Apache License, Version 2.0 (the "License");
 : # you may not use this file except in compliance with the License.
@@ -31,17 +31,16 @@ GOTO :CMDSCRIPT
 : # For each palisade repo
 for dir in Palisade-common Palisade-readers Palisade-clients Palisade-services Palisade-examples
 do
-    # Clone it (0.4.0 release)
-    git clone --depth 1 --branch palisade-0.4.0 https://github.com/gchq/$dir.git
+    # Clone it (0.5.0 release)
+    git clone --depth 1 --branch palisade-0.5.0 https://github.com/gchq/$dir.git
     cd $dir
     # Install it (skip dockerfile, tests, javadoc, etc.)
     ../mvnw install -Pquick
-    cd ..
+    cd ..:
 done
 
 : # Run the REST example
 cd Palisade-services
-java -Dspring.profiles.active=discovery -Dmanager.mode=run -jar services-manager/target/services-manager-*-exec.jar
 java -Dspring.profiles.active=example-runner -Dmanager.mode=run -jar services-manager/target/services-manager-*-exec.jar
 cat rest-example.log
 cd ..
@@ -61,7 +60,7 @@ set "dir_list=Palisade-common Palisade-readers Palisade-clients Palisade-service
 FOR %%s IN (%dir_list%) DO (
     set "url=https://github.com/gchq/%%s.git"
     REM clone it
-    git clone --depth 1 --branch palisade-0.4.0 "!url!"
+    git clone --depth 1 --branch palisade-0.5.0 "!url!"
     cd %%s
     REM install it
     call ../mvnw.cmd install -Pquick
@@ -70,7 +69,6 @@ FOR %%s IN (%dir_list%) DO (
 
 : # Run the REST example
 cd Palisade-services
-java -D"spring.profiles.active=discovery" -D"manager.mode=run" -jar services-manager/target/services-manager-0.4.0-exec.jar
-java -D"spring.profiles.active=example-runner" -D"manager.mode=run" -jar services-manager/target/services-manager-0.4.0-exec.jar
+java -D"spring.profiles.active=example-runner" -D"manager.mode=run" -jar services-manager/target/services-manager-0.5.0-exec.jar
 cat rest-example.log
 cd ..

--- a/quickstart.cmd
+++ b/quickstart.cmd
@@ -41,7 +41,7 @@ done
 
 : # Run the REST example
 cd Palisade-services
-java -Dspring.profiles.active=example-runner -Dmanager.mode=run -jar services-manager/target/services-manager-*-exec.jar
+java -Dspring.profiles.active=example-runner -Dmanager.mode=run -jar services-manager/target/services-manager-0.5.0-exec.jar
 cat rest-example.log
 cd ..
 

--- a/quickstop.cmd
+++ b/quickstop.cmd
@@ -17,5 +17,4 @@
 : # Stop after running the REST example
 cd Palisade-services
 java -D"spring.profiles.active=example-runner" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.5.0-exec.jar
-java -D"spring.profiles.active=discovery" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.5.0-exec.jar
 cd ..

--- a/quickstop.cmd
+++ b/quickstop.cmd
@@ -16,6 +16,6 @@
 
 : # Stop after running the REST example
 cd Palisade-services
-java -D"spring.profiles.active=example-model" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.4.0-exec.jar
+java -D"spring.profiles.active=example-runner" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.4.0-exec.jar
 java -D"spring.profiles.active=discovery" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.4.0-exec.jar
 cd ..

--- a/quickstop.cmd
+++ b/quickstop.cmd
@@ -1,4 +1,4 @@
-: # Copyright 2020 Crown Copyright
+: # Copyright 2018-2021 Crown Copyright
 : #
 : # Licensed under the Apache License, Version 2.0 (the "License");
 : # you may not use this file except in compliance with the License.
@@ -16,6 +16,6 @@
 
 : # Stop after running the REST example
 cd Palisade-services
-java -D"spring.profiles.active=example-runner" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.4.0-exec.jar
-java -D"spring.profiles.active=discovery" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.4.0-exec.jar
+java -D"spring.profiles.active=example-runner" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.5.0-exec.jar
+java -D"spring.profiles.active=discovery" -D"manager.mode=shutdown" -jar services-manager/target/services-manager-0.5.0-exec.jar
 cd ..


### PR DESCRIPTION
~Requires all repos to be tagged with `palisade-0.5.0` once happy with the state of 0.5.0 release~
Currently uses `develop`, a future update may freeze this to an 0.5.0 tag